### PR TITLE
Sync buildpack 24

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,57 +1,13 @@
 #!/usr/bin/env bash
-
-# Forzar uso de curl del sistema y agregar debug
 set -e
 export PATH="/usr/bin:/bin:$PATH"
 CURL="/usr/bin/curl"
 echo "Using curl at: $(command -v curl)"
 $CURL --version || true
 
-indent() {
-  while IFS= read -r line; do
-    printf '       %s\n' "$line"
-  done
-}
-
-export_env_dir() {
-  env_dir=$1
-  whitelist_regex=${2:-''}
-  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|JAVA_OPTS)$'}
-  if [ -d "$env_dir" ]; then
-    for e in $(ls "$env_dir"); do
-      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
-      export "$e=$(cat "$env_dir/$e")"
-    done
-  fi
-}
-
-get_play_version() {
-  local file=${1?"No file specified"}
-  if [ ! -f "$file" ]; then
-    echo ""
-    return 0
-  fi
-  grep -P '.*-.*play[ \t]+[0-9\.]+' "$file" | sed -E -e 's/[ \t]*-[ \t]*play[ \t]+([0-9A-Za-z\.]*).*/\1/'
-}
-
-check_compile_status() {
-  if [ "${PIPESTATUS[*]}" != "0 0" ]; then
-    echo " !     Failed to build Play! application"
-    rm -rf "$CACHE_DIR/$PLAY_PATH"
-    echo " !     Cleared Play! framework from cache"
-    exit 1
-  fi
-}
-
 download_play_official() {
   local playVersion=${1}
   local playTarFile=${2}
-
-  if [ -z "$playVersion" ]; then
-    echo "ERROR: playVersion vacío, no se puede descargar Play!"
-    exit 1
-  fi
-
   local playZipFile="play-${playVersion}.zip"
   local playUrl="https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/play-1.4.5.zip"
 
@@ -64,114 +20,35 @@ download_play_official() {
 
   echo "Preparing binary package..."
   local playUnzipDir="tmp-play-unzipped/"
-  mkdir -p ${playUnzipDir}
-  
-  echo "Zip file: $playZipFile"
-  if [ ! -f ${playZipFile} ]; then
+  mkdir -p "${playUnzipDir}"
+
+  echo "Zip file: ${playZipFile}"
+  if [ ! -f "${playZipFile}" ]; then
     echo "Error: Zip file not found."
     exit 1
   fi
-  
-  unzip ${playZipFile} -d ${playUnzipDir} > /dev/null 2>&1
 
-  PLAY_BUILD_DIR=$(find ${playUnzipDir} -name 'framework' -type d | sed 's/framework//')
+  unzip "${playZipFile}" -d "${playUnzipDir}" > /dev/null 2>&1
+  PLAY_BUILD_DIR=$(find "${playUnzipDir}" -name 'framework' -type d | sed 's/framework//')
 
-  # Crear estructura de .play
-  mkdir -p .play/framework/src/play
-  mkdir -p .play/framework/pym
-  mkdir -p .play/modules
-  mkdir -p .play/resources
+  mkdir -p .play/framework/src/play .play/framework/pym .play/modules .play/resources
 
-  cp -r "$PLAY_BUILD_DIR/framework/dependencies.yml" .play/framework
-  cp -r "$PLAY_BUILD_DIR/framework/lib/" .play/framework
-  cp -r "$PLAY_BUILD_DIR/framework/play-"*.jar .play/framework
-  cp -r "$PLAY_BUILD_DIR/framework/pym/" .play/framework
-  cp -r "$PLAY_BUILD_DIR/framework/src/play/version" .play/framework/src/play
-  cp -r "$PLAY_BUILD_DIR/framework/templates/" .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/dependencies.yml"   .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/lib/"               .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/play-"*.jar         .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/pym/"               .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/src/play/version"   .play/framework/src/play
+  cp -r "${PLAY_BUILD_DIR}/framework/templates/"         .play/framework
 
-  cp -r "$PLAY_BUILD_DIR/modules" .play
-  cp -r "$PLAY_BUILD_DIR/play" .play
-  cp -r "$PLAY_BUILD_DIR/resources" .play
+  cp -r "${PLAY_BUILD_DIR}/modules"   .play
+  cp -r "${PLAY_BUILD_DIR}/play"      .play
+  cp -r "${PLAY_BUILD_DIR}/resources" .play
 
   chmod +x .play/play
 }
 
-validate_play_version() {
-  local playVersion=${1}
-  if [ "$playVersion" == "1.4.0" ] || [ "$playVersion" == "1.3.2" ]; then
-    echo "Unsupported version: $playVersion"
-    echo "This version of Play! is incompatible with Linux. Upgrade to a newer version."
-    exit 1
-  elif [[ "$playVersion" =~ ^2.* ]]; then
-    echo "Unsupported version: Play 2.x requires the Scala buildpack"
-    exit 1
-  fi
-}
-
 install_openjdk() {
-  local java_version=$1
-  local build_dir=$2
-  local bin_dir=$3
-
-  echo "Installing OpenJDK version $java_version..."
-
-  JDK_DIR="$build_dir/.jdk"
-  mkdir -p "$JDK_DIR"
-
-  if [[ "$java_version" == "1.8" || "$java_version" == "8" ]]; then
-    JDK_URL="https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/jre-8u431-linux-x64.tar.gz"
-  else
-    echo "Unsupported Java version $java_version"
-    exit 1
-  fi
-
-  echo "Downloading JDK from: $JDK_URL"
-  $CURL -sS -L --fail "$JDK_URL" | tar xz -C "$JDK_DIR" --strip-components=1
+  echo "Downloading JDK from: ${JDK_URL}"
+  $CURL -sS -L --fail "${JDK_URL}" | tar xz -C "${JDK_DIR}" --strip-components=1
   echo "OpenJDK installed to $JDK_DIR"
-}
-
-install_play() {
-  VER_TO_INSTALL=$1
-  if [ -z "$VER_TO_INSTALL" ]; then
-    echo "ERROR: VER_TO_INSTALL vacío, no se puede instalar Play!"
-    exit 1
-  fi
-
-  PLAY_URL="https://s3.amazonaws.com/heroku-jvm-langpack-play/play-heroku-$VER_TO_INSTALL.tar.gz"
-  PLAY_TAR_FILE="play-heroku.tar.gz"
-
-  validate_play_version "$VER_TO_INSTALL"
-
-  echo "-----> Installing Play! $VER_TO_INSTALL....."
-
-  status=$($CURL --retry 3 --silent --head -L -w "%{http_code}" -o /dev/null "$PLAY_URL")
-
-  if [ "$status" != "200" ]; then
-    download_play_official "$VER_TO_INSTALL" "$PLAY_TAR_FILE"
-  else
-    $CURL --retry 3 -sS --max-time 150 -L --fail "$PLAY_URL" -o "$PLAY_TAR_FILE"
-  fi
-
-  if [ ! -f "$PLAY_TAR_FILE" ]; then
-    echo "-----> Error downloading Play! framework. Please try again..."
-    exit 1
-  fi
-
-  if ! file "$PLAY_TAR_FILE" | grep -q gzip; then
-    echo "Failed to install Play! framework or unsupported Play! framework version specified."
-    exit 1
-  fi
-
-  tar xzmf "$PLAY_TAR_FILE"
-  rm "$PLAY_TAR_FILE"
-  chmod +x "$PLAY_PATH/play"
-  echo "Done installing Play!" | indent
-}
-
-remove_play() {
-  local build_dir=$1
-  local play_version=$2
-
-  rm -rf "${build_dir}/tmp-play-unzipped"
-  rm -f "${build_dir}/play-${play_version}.zip"
 }

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -193,3 +193,21 @@ remove_play() {
   rm -rf "${build_dir}/tmp-play-unzipped"
   rm -f "${build_dir}/play-${play_version}.zip"
 }
+
+install_python3() {
+  local build_dir="$1"
+  local py_dir="$build_dir/.python3"
+  mkdir -p "$py_dir"
+
+  # Python 3 portable para Linux x64 (compatible con heroku-24)
+  local url="https://cdn.heroku.com/buildpack-python/portable-python/3.12.3/linux-x64.tar.gz"
+
+  echo "Installing portable Python3 from: $url"
+  /usr/bin/curl -sSL "$url" | tar xz -C "$py_dir" --strip-components=1
+
+  # Export en runtime para que 'python3' esté en el PATH del dyno
+  mkdir -p "$build_dir/.profile.d"
+  cat > "$build_dir/.profile.d/python3.sh" <<'EOF'
+export PATH="/app/.python3/bin:$PATH"
+EOF
+}

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -193,21 +193,3 @@ remove_play() {
   rm -rf "${build_dir}/tmp-play-unzipped"
   rm -f "${build_dir}/play-${play_version}.zip"
 }
-
-install_python3() {
-  local build_dir="$1"
-  local py_dir="$build_dir/.python3"
-  mkdir -p "$py_dir"
-
-  # Python 3 portable para Linux x64 (compatible con heroku-24)
-  local url="https://cdn.heroku.com/buildpack-python/portable-python/3.12.3/linux-x64.tar.gz"
-
-  echo "Installing portable Python3 from: $url"
-  /usr/bin/curl -sSL "$url" | tar xz -C "$py_dir" --strip-components=1
-
-  # Export en runtime para que 'python3' esté en el PATH del dyno
-  mkdir -p "$build_dir/.profile.d"
-  cat > "$build_dir/.profile.d/python3.sh" <<'EOF'
-export PATH="/app/.python3/bin:$PATH"
-EOF
-}

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,13 +1,109 @@
 #!/usr/bin/env bash
 set -e
+
+# --- Forzar el curl del sistema y agregar debug útil ---
 export PATH="/usr/bin:/bin:$PATH"
 CURL="/usr/bin/curl"
 echo "Using curl at: $(command -v curl)"
 $CURL --version || true
 
+# ========== Utilidades generales ==========
+indent() {
+  while IFS= read -r line; do
+    printf '       %s\n' "$line"
+  done
+}
+
+export_env_dir() {
+  env_dir=$1
+  whitelist_regex=${2:-''}
+  blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|JAVA_OPTS)$'}
+  if [ -d "$env_dir" ]; then
+    for e in $(ls "$env_dir"); do
+      echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+      export "$e=$(cat "$env_dir/$e")"
+    done
+  fi
+}
+
+# Devuelve solo el número de versión (e.g., 1.8.0) desde conf/dependencies.yml
+get_play_version() {
+  local file=${1?"No file specified"}
+  if [ ! -f "$file" ]; then
+    echo ""
+    return 0
+  fi
+  # Línea que empieza con "- play <version>", quitar comentarios y CR, y extraer el segundo campo
+  grep -iE '^[[:space:]]*-[[:space:]]+play[[:space:]]+[0-9A-Za-z\.\-]+' "$file" \
+    | head -1 \
+    | sed 's/#.*//' \
+    | tr -d '\r' \
+    | awk '{print $3}'
+}
+
+# Verifica el estatus de un pipeline "cmd | sed" (usado en compile)
+check_compile_status() {
+  local arr=("${PIPESTATUS[@]}")
+  for s in "${arr[@]}"; do
+    if [ "$s" != "0" ]; then
+      echo " !     Failed to build Play! application"
+      exit 1
+    fi
+  done
+}
+
+validate_play_version() {
+  local playVersion=${1}
+  if [ "$playVersion" = "1.4.0" ] || [ "$playVersion" = "1.3.2" ]; then
+    echo "Unsupported version: $playVersion (incompatible con Linux)."
+    exit 1
+  elif [[ "$playVersion" =~ ^2.* ]]; then
+    echo "Unsupported version: Play 2.x requiere el Scala buildpack."
+    exit 1
+  fi
+}
+
+# ========== Java / JDK ==========
+# Firma esperada por compile: install_openjdk "1.8" "$BUILD_DIR" "$BIN_DIR"
+install_openjdk() {
+  local java_version="$1"
+  local build_dir="$2"
+  local bin_dir="$3"
+
+  echo "Installing OpenJDK version ${java_version}..."
+
+  local JDK_DIR="${build_dir}/.jdk"
+  mkdir -p "${JDK_DIR}"
+
+  # Construir URL si no está definida externamente
+  local JDK_URL_LOCAL=""
+  if [[ "$java_version" == "1.8" || "$java_version" == "8" ]]; then
+    # Default probado en tu fork (JRE 8u431)
+    JDK_URL_LOCAL="https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/jre-8u431-linux-x64.tar.gz"
+  else
+    echo "Unsupported Java version ${java_version}"
+    exit 1
+  fi
+
+  # Permitir override si alguien exportó JDK_URL antes de llamar
+  local EFFECTIVE_JDK_URL="${JDK_URL:-$JDK_URL_LOCAL}"
+
+  echo "Downloading JDK from: ${EFFECTIVE_JDK_URL}"
+  $CURL -sS -L --fail "${EFFECTIVE_JDK_URL}" | tar xz -C "${JDK_DIR}" --strip-components=1
+  echo "OpenJDK installed to ${JDK_DIR}"
+}
+
+# ========== Play! framework ==========
+# Descarga oficial de Play 1.x desde GitHub Releases
 download_play_official() {
   local playVersion=${1}
-  local playTarFile=${2}
+  local playTarget=${2}   # no se usa como archivo, mantenido por compatibilidad
+
+  if [ -z "$playVersion" ]; then
+    echo "ERROR: playVersion vacío, no se puede descargar Play!"
+    exit 1
+  fi
+
   local playZipFile="play-${playVersion}.zip"
   local playUrl="https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/play-1.4.5.zip"
 
@@ -19,7 +115,7 @@ download_play_official() {
   $CURL --retry 3 -sS -O -L --fail "${playUrl}"
 
   echo "Preparing binary package..."
-  local playUnzipDir="tmp-play-unzipped/"
+  local playUnzipDir="tmp-play-unzipped"
   mkdir -p "${playUnzipDir}"
 
   echo "Zip file: ${playZipFile}"
@@ -28,17 +124,25 @@ download_play_official() {
     exit 1
   fi
 
-  unzip "${playZipFile}" -d "${playUnzipDir}" > /dev/null 2>&1
-  PLAY_BUILD_DIR=$(find "${playUnzipDir}" -name 'framework' -type d | sed 's/framework//')
+  unzip -q "${playZipFile}" -d "${playUnzipDir}"
 
+  # Buscar el directorio raíz del zip (donde vive 'framework')
+  local PLAY_BUILD_DIR
+  PLAY_BUILD_DIR=$(find "${playUnzipDir}" -type d -name 'framework' | head -1 | sed 's#/framework##')
+  if [ -z "${PLAY_BUILD_DIR}" ]; then
+    echo "Error: no se encontró el directorio 'framework' dentro del zip."
+    exit 1
+  fi
+
+  # Crear estructura final
   mkdir -p .play/framework/src/play .play/framework/pym .play/modules .play/resources
 
-  cp -r "${PLAY_BUILD_DIR}/framework/dependencies.yml"   .play/framework
-  cp -r "${PLAY_BUILD_DIR}/framework/lib/"               .play/framework
-  cp -r "${PLAY_BUILD_DIR}/framework/play-"*.jar         .play/framework
-  cp -r "${PLAY_BUILD_DIR}/framework/pym/"               .play/framework
-  cp -r "${PLAY_BUILD_DIR}/framework/src/play/version"   .play/framework/src/play
-  cp -r "${PLAY_BUILD_DIR}/framework/templates/"         .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/dependencies.yml"       .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/lib/"                   .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/play-"*.jar             .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/pym/"                   .play/framework
+  cp -r "${PLAY_BUILD_DIR}/framework/src/play/version"       .play/framework/src/play
+  cp -r "${PLAY_BUILD_DIR}/framework/templates/"             .play/framework
 
   cp -r "${PLAY_BUILD_DIR}/modules"   .play
   cp -r "${PLAY_BUILD_DIR}/play"      .play
@@ -47,8 +151,42 @@ download_play_official() {
   chmod +x .play/play
 }
 
-install_openjdk() {
-  echo "Downloading JDK from: ${JDK_URL}"
-  $CURL -sS -L --fail "${JDK_URL}" | tar xz -C "${JDK_DIR}" --strip-components=1
-  echo "OpenJDK installed to $JDK_DIR"
+install_play() {
+  local VER_TO_INSTALL="$1"
+  if [ -z "$VER_TO_INSTALL" ]; then
+    echo "ERROR: VER_TO_INSTALL vacío, no se puede instalar Play!"
+    exit 1
+  fi
+
+  local PLAY_URL="https://s3.amazonaws.com/heroku-jvm-langpack-play/play-heroku-${VER_TO_INSTALL}.tar.gz"
+  local PLAY_TAR_FILE="play-heroku.tar.gz"
+
+  validate_play_version "$VER_TO_INSTALL"
+  echo "-----> Installing Play! ${VER_TO_INSTALL}....."
+
+  local status
+  status=$($CURL --retry 3 --silent --head -L -w "%{http_code}" -o /dev/null "${PLAY_URL}")
+
+  if [ "$status" != "200" ]; then
+    # Fallback: descargar el zip oficial y ensamblar .play/
+    download_play_official "$VER_TO_INSTALL" "$PLAY_TAR_FILE"
+  else
+    $CURL --retry 3 -sS --max-time 150 -L --fail "${PLAY_URL}" -o "${PLAY_TAR_FILE}"
+    if ! file "${PLAY_TAR_FILE}" | grep -q gzip; then
+      echo "Failed to install Play! framework or unsupported Play! framework version specified."
+      exit 1
+    fi
+    tar xzmf "${PLAY_TAR_FILE}"
+    rm -f "${PLAY_TAR_FILE}"
+    chmod +x ".play/play"
+  fi
+
+  echo "Done installing Play!" | indent
+}
+
+remove_play() {
+  local build_dir=$1
+  local play_version=$2
+  rm -rf "${build_dir}/tmp-play-unzipped"
+  rm -f "${build_dir}/play-${play_version}.zip"
 }

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -86,7 +86,7 @@ install_openjdk() {
   else
     echo "Unsupported Java version ${java_version}"
     exit 1
-  fi`
+  fi
 
   # Permitir override vía env var JDK_URL
   local EFFECTIVE_JDK_URL="${JDK_URL:-$JDK_URL_LOCAL}"

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -75,17 +75,20 @@ install_openjdk() {
   local JDK_DIR="${build_dir}/.jdk"
   mkdir -p "${JDK_DIR}"
 
-  # Construir URL si no está definida externamente
+  # URL por defecto según versión solicitada
   local JDK_URL_LOCAL=""
   if [[ "$java_version" == "1.8" || "$java_version" == "8" ]]; then
-    # Default probado en tu fork (JRE 8u431)
+    # JRE 8 (tu release actual)
     JDK_URL_LOCAL="https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/jre-8u431-linux-x64.tar.gz"
+  elif [[ "$java_version" == "11" || "$java_version" == "11."* ]]; then
+    # JDK 11 LTS (OpenLogic build; Linux x64, compatible con Heroku-24)
+    JDK_URL_LOCAL="https://builds.openlogic.com/downloadJDK/openlogic-openjdk/11.0.28+8/linux/x64/openlogic-openjdk-11.0.28+8-linux-x64.tar.gz"
   else
     echo "Unsupported Java version ${java_version}"
     exit 1
-  fi
+  fi`
 
-  # Permitir override si alguien exportó JDK_URL antes de llamar
+  # Permitir override vía env var JDK_URL
   local EFFECTIVE_JDK_URL="${JDK_URL:-$JDK_URL_LOCAL}"
 
   echo "Downloading JDK from: ${EFFECTIVE_JDK_URL}"

--- a/bin/compile
+++ b/bin/compile
@@ -19,7 +19,7 @@ export_env_dir "$ENV_DIR" || true
 # --- Asegurar cache dir ---
 mkdir -p "$CACHE_DIR"
 
-# --- Java 11 por defecto si no hay system.properties ---
+# --- Java 11 por defecto si no hay system.properties (solo meta; heroku/jvm ya instala 11) ---
 if [ ! -f "$BUILD_DIR/system.properties" ]; then
   echo "java.runtime.version=11" > "$BUILD_DIR/system.properties"
 fi
@@ -73,13 +73,18 @@ export LD_LIBRARY_PATH="/app/.python2/lib:$LD_LIBRARY_PATH"
 EOF
 chmod +x "$BUILD_DIR/.play-wrapper"
 
-# --- Instalar OpenJDK 11 (lo hace common.sh con /usr/bin/curl) ---
-echo "-----> Installing OpenJDK 11..."
-install_openjdk "11" "$BUILD_DIR" "$BIN_DIR"
-echo "       Done installing OpenJDK 11"
+# --- Java 11: usar el que instala heroku/jvm; NO volver a descargar ---
+echo "-----> Using Java from heroku/jvm buildpack if available..."
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  echo "       JAVA_HOME provided by heroku/jvm: $JAVA_HOME"
+else
+  echo "       WARNING: JAVA_HOME not set by heroku/jvm; falling back to manual install..."
+  # Solo si de verdad no vino JAVA_HOME, instalamos nosotros (usa install_openjdk "11" si tu common.sh lo soporta)
+  install_openjdk "11" "$BUILD_DIR" "$BIN_DIR"
+  export JAVA_HOME="$BUILD_DIR/.jdk"
+fi
 
-# **AQUÍ** exportamos JAVA_HOME y actualizamos PATH para que Play lo vea durante el build
-export JAVA_HOME="$BUILD_DIR/.jdk"
+# Asegurar en cualquier caso:
 export PATH="$JAVA_HOME/bin:$PATH"
 echo "JAVA_HOME=$JAVA_HOME"
 java -version || true

--- a/bin/compile
+++ b/bin/compile
@@ -19,9 +19,9 @@ export_env_dir "$ENV_DIR" || true
 # --- Asegurar cache dir ---
 mkdir -p "$CACHE_DIR"
 
-# --- Java 1.8 por defecto si no hay system.properties ---
+# --- Java 11 por defecto si no hay system.properties ---
 if [ ! -f "$BUILD_DIR/system.properties" ]; then
-  echo "java.runtime.version=1.8" > "$BUILD_DIR/system.properties"
+  echo "java.runtime.version=11" > "$BUILD_DIR/system.properties"
 fi
 
 # --- Instalar Python 2.7 portable (para tooling de Play 1) ---
@@ -73,10 +73,10 @@ export LD_LIBRARY_PATH="/app/.python2/lib:$LD_LIBRARY_PATH"
 EOF
 chmod +x "$BUILD_DIR/.play-wrapper"
 
-# --- Instalar OpenJDK 1.8 (lo hace common.sh con /usr/bin/curl) ---
-echo "-----> Installing OpenJDK..."
-install_openjdk "1.8" "$BUILD_DIR" "$BIN_DIR"
-echo "       Done installing OpenJDK"
+# --- Instalar OpenJDK 11 (lo hace common.sh con /usr/bin/curl) ---
+echo "-----> Installing OpenJDK 11..."
+install_openjdk "11" "$BUILD_DIR" "$BIN_DIR"
+echo "       Done installing OpenJDK 11"
 
 # **AQUÍ** exportamos JAVA_HOME y actualizamos PATH para que Play lo vea durante el build
 export JAVA_HOME="$BUILD_DIR/.jdk"

--- a/bin/compile
+++ b/bin/compile
@@ -10,10 +10,6 @@ ENV_DIR="$3"
 BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$BIN_DIR/common.sh"
 
-# Añadir Python 3 para heroku-24 (no requiere tocar el repo de la app)
-install_python3 "$BUILD_DIR"
-echo "python3 available? $(/bin/bash -lc 'command -v python3 || true')"
-
 # --- Utilidad para imprimir con indent ---
 indent() { while IFS= read -r line; do printf '       %s\n' "$line"; done; }
 

--- a/bin/compile
+++ b/bin/compile
@@ -171,7 +171,7 @@ rm -rf "$IVY_PATH"
 remove_play "$BUILD_DIR" "$PLAY_VERSION"
 
 # --- Procfile por defecto si no existe ---
-if [ ! -f Procfile ]; then
-  echo "-----> No Procfile found. Default process: "
-  echo "       play run --http.port=$PORT $PLAY_OPTS"
-fi
+# if [ ! -f Procfile ]; then
+#  echo "-----> No Procfile found. Default process: "
+#  echo "       play run --http.port=$PORT $PLAY_OPTS"
+# fi

--- a/bin/compile
+++ b/bin/compile
@@ -56,28 +56,33 @@ fi
 export PATH="$BUILD_DIR/$PYTHON2_DIR/bin:$PATH"
 export LD_LIBRARY_PATH="$BUILD_DIR/$PYTHON2_DIR/lib:$LD_LIBRARY_PATH"
 
-# Runtime: mantener mismas vars
+# Runtime: mantener mismas vars de Python
 mkdir -p "$BUILD_DIR/.profile.d"
-cat > "$BUILD_DIR/.profile.d/python2.sh" <<EOF
-export PATH="/app/.python2/bin:\$PATH"
-export LD_LIBRARY_PATH="/app/.python2/lib:\$LD_LIBRARY_PATH"
+cat > "$BUILD_DIR/.profile.d/python2.sh" <<'EOF'
+export PATH="/app/.python2/bin:$PATH"
+export LD_LIBRARY_PATH="/app/.python2/lib:$LD_LIBRARY_PATH"
 EOF
 
-# Wrapper para play que exporta LD_LIBRARY_PATH antes de ejecutar
+# Wrapper para play (opcional)
 cat > "$BUILD_DIR/.play-wrapper" <<'EOF'
 #!/bin/bash
+export JAVA_HOME="/app/.jdk"
+export PATH="/app/.jdk/bin:$PATH"
 export LD_LIBRARY_PATH="/app/.python2/lib:$LD_LIBRARY_PATH"
 /app/.play/play "$@"
 EOF
 chmod +x "$BUILD_DIR/.play-wrapper"
 
-# --- Instalar OpenJDK 1.8 (el common.sh ya usa /usr/bin/curl y valida URL) ---
+# --- Instalar OpenJDK 1.8 (lo hace common.sh con /usr/bin/curl) ---
 echo "-----> Installing OpenJDK..."
-JDK_DIR="$BUILD_DIR/.jdk"
-mkdir -p "$JDK_DIR"
-# El common.sh espera JDK_URL seteada dentro de install_openjdk; si no, la fija para 1.8
 install_openjdk "1.8" "$BUILD_DIR" "$BIN_DIR"
 echo "       Done installing OpenJDK"
+
+# **AQUÍ** exportamos JAVA_HOME y actualizamos PATH para que Play lo vea durante el build
+export JAVA_HOME="$BUILD_DIR/.jdk"
+export PATH="$JAVA_HOME/bin:$PATH"
+echo "JAVA_HOME=$JAVA_HOME"
+java -version || true
 
 # --- Paths de Play e Ivy ---
 PLAY_PATH=".play"
@@ -101,7 +106,7 @@ if [ -d "${IVY_PATH}-overlay" ]; then
   mv "${IVY_PATH}-overlay"/* "$IVY_PATH"
 fi
 
-# --- Detectar versión de Play desde conf/dependencies.yml (función del common.sh) ---
+# --- Detectar versión de Play desde conf/dependencies.yml ---
 PLAY_VERSION="$(get_play_version "$BUILD_DIR/conf/dependencies.yml")"
 DEFAULT_PLAY_VERSION="1.3.1"
 VERSION_DECLARED=true
@@ -112,7 +117,7 @@ if [ -z "$PLAY_VERSION" ]; then
   echo "-----> WARNING: Play! version not specified in dependencies.yml. Using default: $PLAY_VERSION"
 fi
 
-# --- Instalar/actualizar Play (preferir flujo centralizado del common.sh) ---
+# --- Instalar/actualizar Play ---
 if [ ! -f "$PLAY_PATH/play" ]; then
   install_play "$PLAY_VERSION"
 else
@@ -147,11 +152,13 @@ for DIR in "$PLAY_PATH" "$IVY_PATH"; do
   cp -r "$DIR" "$CACHE_DIR/$DIR"
 done
 
-# --- PATH de runtime ---
+# --- Variables de runtime (JAVA_HOME y PATH) ---
 PROFILE_PATH="$BUILD_DIR/.profile.d/play.sh"
 mkdir -p "$(dirname "$PROFILE_PATH")"
-cat > "$PROFILE_PATH" <<EOF
-export PATH="/app/.play:/app/.jdk/bin:/app/.tools:\$PATH"
+cat > "$PROFILE_PATH" <<'EOF'
+# Runtime env for Play 1 on Heroku
+export JAVA_HOME="/app/.jdk"
+export PATH="/app/.play:/app/.jdk/bin:/app/.tools:$PATH"
 EOF
 
 # --- Limpiar deps de build ---
@@ -161,5 +168,5 @@ remove_play "$BUILD_DIR" "$PLAY_VERSION"
 # --- Procfile por defecto si no existe ---
 if [ ! -f Procfile ]; then
   echo "-----> No Procfile found. Default process: "
-  echo "       play run --http.port=\$PORT \$PLAY_OPTS"
+  echo "       play run --http.port=$PORT $PLAY_OPTS"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -10,6 +10,10 @@ ENV_DIR="$3"
 BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$BIN_DIR/common.sh"
 
+# Añadir Python 3 para heroku-24 (no requiere tocar el repo de la app)
+install_python3 "$BUILD_DIR"
+echo "python3 available? $(/bin/bash -lc 'command -v python3 || true')"
+
 # --- Utilidad para imprimir con indent ---
 indent() { while IFS= read -r line; do printf '       %s\n' "$line"; done; }
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,164 +1,37 @@
 #!/usr/bin/env bash
 set -e
-
 BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
-BIN_DIR=$(cd "$(dirname "$0")"; pwd)
 
-# Load common functions
-. "$BIN_DIR/common.sh"
+source "$BUILD_DIR/bin/common.sh"
 
-# --- Install portable Python 2 ---
-PYTHON2_VERSION="2.7.18"
-PYTHON2_DIR=".python2"
-PYTHON2_BUILD_DIR="Python-${PYTHON2_VERSION}"
-
-if [ ! -d "$BUILD_DIR/$PYTHON2_DIR" ]; then
-  echo "-----> Downloading and compiling Python ${PYTHON2_VERSION}..."
-  curl -L -o python2.tgz "https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/Python-2.7.18.tgz"
-
-  tar -xzf python2.tgz
-  rm python2.tgz
-
-  # Extrae dentro de BUILD_DIR si no se extrajo correctamente
-  if [ ! -d "$BUILD_DIR/$PYTHON2_BUILD_DIR" ] && [ -d "$PYTHON2_BUILD_DIR" ]; then
-    mv "$PYTHON2_BUILD_DIR" "$BUILD_DIR/"
-  fi
-
-  cd "$BUILD_DIR/$PYTHON2_BUILD_DIR"
-
-  ./configure --prefix="$BUILD_DIR/$PYTHON2_DIR" --enable-unicode=ucs4 --enable-shared
-  make -j$(nproc)
-  make install
-
-  cd "$BUILD_DIR"
-  rm -rf "$PYTHON2_BUILD_DIR"
-
-  echo "-----> Python ${PYTHON2_VERSION} compiled and installed at $PYTHON2_DIR"
-else
-  echo "-----> Python ${PYTHON2_VERSION} already installed"
-fi
-
-# Aseguramos que el binario y la lib compartida estén disponibles en build y runtime
-export PATH="$BUILD_DIR/$PYTHON2_DIR/bin:$PATH"
-export LD_LIBRARY_PATH="$BUILD_DIR/$PYTHON2_DIR/lib:$LD_LIBRARY_PATH"
-
-# Runtime profile to export same LD_LIBRARY_PATH
-PY2_PROFILE="$BUILD_DIR/.profile.d/python2.sh"
-mkdir -p "$(dirname "$PY2_PROFILE")"
-cat <<EOF > "$PY2_PROFILE"
-export PATH="/app/.python2/bin:\$PATH"
-export LD_LIBRARY_PATH="/app/.python2/lib:\$LD_LIBRARY_PATH"
-EOF
-
-# Crea un wrapper para play que exporta LD_LIBRARY_PATH antes de ejecutarlo
-cat <<EOF > "$BUILD_DIR/.play-wrapper"
-#!/bin/bash
-export LD_LIBRARY_PATH="/app/.python2/lib:\$LD_LIBRARY_PATH"
-/app/.play/play "\$@"
-EOF
-chmod +x "$BUILD_DIR/.play-wrapper"
-
-export_env_dir "$ENV_DIR"
-
-# Ensure cache dir exists
-mkdir -p "$CACHE_DIR"
-
-# Default system.properties (Java 1.8)
-if [ ! -f "$BUILD_DIR/system.properties" ]; then
-  echo "java.runtime.version=1.8" > "$BUILD_DIR/system.properties"
-fi
+echo "-----> Installing Python 2.7..."
+/usr/bin/curl -L -o python2.tgz "https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/Python-2.7.18.tgz"
+mkdir -p .python2
+tar -xzf python2.tgz -C .python2 --strip-components=1
+rm python2.tgz
+echo "-----> Python 2.7 installed."
 
 echo "-----> Installing OpenJDK..."
-javaVersion="1.8"
-install_openjdk "$javaVersion" "$BUILD_DIR" "$BIN_DIR"
-echo "       Done installing OpenJDK"
+JDK_URL="https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/jre-8u431-linux-x64.tar.gz"
+JDK_DIR="$BUILD_DIR/.jdk"
+mkdir -p "$JDK_DIR"
+install_openjdk
 
-PLAY_PATH=".play"
-IVY_PATH=".ivy2"
+echo "-----> Installing Play! Framework..."
+PLAY_VERSION=$(grep -i "play" conf/dependencies.yml | head -1 | awk '{print $2}')
+PLAY_PATH="$BUILD_DIR/.play"
 
-cd "$BUILD_DIR"
-
-# Restore cache for Play and Ivy dirs
-for DIR in "$PLAY_PATH" "$IVY_PATH"; do
-  rm -rf "$DIR"
-  if [ -d "$CACHE_DIR/$DIR" ]; then
-    echo "Restoring cache for $DIR"
-    cp -r "$CACHE_DIR/$DIR" "$DIR"
-  fi
-done
-
-# Install custom Ivy settings if present
-if [ -d "${IVY_PATH}-overlay" ]; then
-  echo "-----> Installing custom Ivy files..."
-  mkdir -p "$IVY_PATH"
-  mv "${IVY_PATH}-overlay"/* "$IVY_PATH"
-fi
-
-# Determine Play version
-PLAY_VERSION=$(get_play_version conf/dependencies.yml)
-DEFAULT_PLAY_VERSION="1.3.1"
-VERSION_DECLARED=true
-
-if [ -z "$PLAY_VERSION" ]; then
-  PLAY_VERSION="$DEFAULT_PLAY_VERSION"
-  VERSION_DECLARED=false
-  echo "-----> WARNING: Play! version not specified in dependencies.yml. Using default: $PLAY_VERSION"
-fi
-
-# Install or update Play framework
 if [ ! -f "$PLAY_PATH/play" ]; then
   download_play_official "$PLAY_VERSION" "$PLAY_PATH"
 else
   INSTALLED_PLAY_VERSION=$(cat "$PLAY_PATH/framework/src/play/version")
-  if [ "$INSTALLED_PLAY_VERSION" != "$PLAY_VERSION" ] && $VERSION_DECLARED; then
+  if [ "$INSTALLED_PLAY_VERSION" != "$PLAY_VERSION" ]; then
     echo "-----> Updating Play! from $INSTALLED_PLAY_VERSION to $PLAY_VERSION..."
     rm -rf "$PLAY_PATH"
     download_play_official "$PLAY_VERSION" "$PLAY_PATH"
   fi
 fi
 
-echo "-----> Building Play! application..."
-"$PLAY_PATH/play" version | sed -u 's/^/       /'
-
-APP_DIR="."
-echo "       Building app at $APP_DIR"
-
-DEPENDENCIES_CMD="$PLAY_PATH/play dependencies $APP_DIR --forProd --forceCopy --silent -Duser.home=$BUILD_DIR 2>&1"
-echo "       Resolving dependencies..."
-eval "$DEPENDENCIES_CMD" | sed -u 's/^/       /'
-check_compile_status
-
-PRECOMPILE_CMD="$PLAY_PATH/play precompile $APP_DIR --silent 2>&1"
-echo "       Precompiling application..."
-eval "$PRECOMPILE_CMD" | sed -u 's/^/       /'
-check_compile_status
-
-# Save cache
-for DIR in "$PLAY_PATH" "$IVY_PATH"; do
-  rm -rf "$CACHE_DIR/$DIR"
-  cp -r "$DIR" "$CACHE_DIR/$DIR"
-done
-
-# Setup .profile.d to set PATH at runtime
-PROFILE_PATH="$BUILD_DIR/.profile.d/play.sh"
-mkdir -p "$(dirname "$PROFILE_PATH")"
-cat <<EOF > "$PROFILE_PATH"
-export PATH="/app/.play:/app/.jdk/bin:/app/.tools:\$PATH"
-EOF
-
-# Setup Python2 path in runtime profile
-PY2_PROFILE="$BUILD_DIR/.profile.d/python2.sh"
-mkdir -p "$(dirname "$PY2_PROFILE")"
-echo 'export PATH="/app/.python2/bin:$PATH"' > "$PY2_PROFILE"
-
-# Clean build-time dependencies
-rm -rf "$IVY_PATH"
-remove_play "$BUILD_DIR" "$PLAY_VERSION"
-
-# Warn if no Procfile
-if [ ! -f Procfile ]; then
-  echo "-----> No Procfile found. Default process: "
-  echo "       play run --http.port=\$PORT \$PLAY_OPTS"
-fi
+echo "-----> Build complete."

--- a/bin/compile
+++ b/bin/compile
@@ -1,37 +1,165 @@
 #!/usr/bin/env bash
 set -e
-BUILD_DIR=$1
-CACHE_DIR=$2
-ENV_DIR=$3
 
-source "$BUILD_DIR/bin/common.sh"
+# --- Args provistos por Heroku buildpacks ---
+BUILD_DIR="$1"
+CACHE_DIR="$2"
+ENV_DIR="$3"
 
-echo "-----> Installing Python 2.7..."
-/usr/bin/curl -L -o python2.tgz "https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/Python-2.7.18.tgz"
-mkdir -p .python2
-tar -xzf python2.tgz -C .python2 --strip-components=1
-rm python2.tgz
-echo "-----> Python 2.7 installed."
+# --- Ubicar y cargar utilidades del propio buildpack ---
+BIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$BIN_DIR/common.sh"
 
+# --- Utilidad para imprimir con indent ---
+indent() { while IFS= read -r line; do printf '       %s\n' "$line"; done; }
+
+# --- Exportar variables de entorno desde ENV_DIR (si existen) ---
+export_env_dir "$ENV_DIR" || true
+
+# --- Asegurar cache dir ---
+mkdir -p "$CACHE_DIR"
+
+# --- Java 1.8 por defecto si no hay system.properties ---
+if [ ! -f "$BUILD_DIR/system.properties" ]; then
+  echo "java.runtime.version=1.8" > "$BUILD_DIR/system.properties"
+fi
+
+# --- Instalar Python 2.7 portable (para tooling de Play 1) ---
+PYTHON2_VERSION="2.7.18"
+PYTHON2_DIR=".python2"
+PYTHON2_BUILD_DIR="Python-${PYTHON2_VERSION}"
+
+if [ ! -d "$BUILD_DIR/$PYTHON2_DIR" ]; then
+  echo "-----> Downloading and compiling Python ${PYTHON2_VERSION}..."
+  /usr/bin/curl -L -o python2.tgz "https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/Python-2.7.18.tgz"
+  tar -xzf python2.tgz
+  rm -f python2.tgz
+
+  # Mover al BUILD_DIR si se extrajo en cwd
+  if [ ! -d "$BUILD_DIR/$PYTHON2_BUILD_DIR" ] && [ -d "$PYTHON2_BUILD_DIR" ]; then
+    mv "$PYTHON2_BUILD_DIR" "$BUILD_DIR/"
+  fi
+
+  cd "$BUILD_DIR/$PYTHON2_BUILD_DIR"
+  ./configure --prefix="$BUILD_DIR/$PYTHON2_DIR" --enable-unicode=ucs4 --enable-shared
+  make -j"$(nproc)"
+  make install
+  cd "$BUILD_DIR"
+  rm -rf "$PYTHON2_BUILD_DIR"
+
+  echo "-----> Python ${PYTHON2_VERSION} compiled and installed at $PYTHON2_DIR"
+else
+  echo "-----> Python ${PYTHON2_VERSION} already installed"
+fi
+
+# PATH/LD_LIBRARY_PATH para build
+export PATH="$BUILD_DIR/$PYTHON2_DIR/bin:$PATH"
+export LD_LIBRARY_PATH="$BUILD_DIR/$PYTHON2_DIR/lib:$LD_LIBRARY_PATH"
+
+# Runtime: mantener mismas vars
+mkdir -p "$BUILD_DIR/.profile.d"
+cat > "$BUILD_DIR/.profile.d/python2.sh" <<EOF
+export PATH="/app/.python2/bin:\$PATH"
+export LD_LIBRARY_PATH="/app/.python2/lib:\$LD_LIBRARY_PATH"
+EOF
+
+# Wrapper para play que exporta LD_LIBRARY_PATH antes de ejecutar
+cat > "$BUILD_DIR/.play-wrapper" <<'EOF'
+#!/bin/bash
+export LD_LIBRARY_PATH="/app/.python2/lib:$LD_LIBRARY_PATH"
+/app/.play/play "$@"
+EOF
+chmod +x "$BUILD_DIR/.play-wrapper"
+
+# --- Instalar OpenJDK 1.8 (el common.sh ya usa /usr/bin/curl y valida URL) ---
 echo "-----> Installing OpenJDK..."
-JDK_URL="https://github.com/Cliengo/heroku-buildpack-play-24/releases/download/heroku-24/jre-8u431-linux-x64.tar.gz"
 JDK_DIR="$BUILD_DIR/.jdk"
 mkdir -p "$JDK_DIR"
-install_openjdk
+# El common.sh espera JDK_URL seteada dentro de install_openjdk; si no, la fija para 1.8
+install_openjdk "1.8" "$BUILD_DIR" "$BIN_DIR"
+echo "       Done installing OpenJDK"
 
-echo "-----> Installing Play! Framework..."
-PLAY_VERSION=$(grep -i "play" conf/dependencies.yml | head -1 | awk '{print $2}')
-PLAY_PATH="$BUILD_DIR/.play"
+# --- Paths de Play e Ivy ---
+PLAY_PATH=".play"
+IVY_PATH=".ivy2"
 
+cd "$BUILD_DIR"
+
+# --- Restaurar cache de Play e Ivy si existe ---
+for DIR in "$PLAY_PATH" "$IVY_PATH"; do
+  rm -rf "$DIR"
+  if [ -d "$CACHE_DIR/$DIR" ]; then
+    echo "Restoring cache for $DIR"
+    cp -r "$CACHE_DIR/$DIR" "$DIR"
+  fi
+done
+
+# --- Ivy overlay opcional ---
+if [ -d "${IVY_PATH}-overlay" ]; then
+  echo "-----> Installing custom Ivy files..."
+  mkdir -p "$IVY_PATH"
+  mv "${IVY_PATH}-overlay"/* "$IVY_PATH"
+fi
+
+# --- Detectar versión de Play desde conf/dependencies.yml (función del common.sh) ---
+PLAY_VERSION="$(get_play_version "$BUILD_DIR/conf/dependencies.yml")"
+DEFAULT_PLAY_VERSION="1.3.1"
+VERSION_DECLARED=true
+
+if [ -z "$PLAY_VERSION" ]; then
+  PLAY_VERSION="$DEFAULT_PLAY_VERSION"
+  VERSION_DECLARED=false
+  echo "-----> WARNING: Play! version not specified in dependencies.yml. Using default: $PLAY_VERSION"
+fi
+
+# --- Instalar/actualizar Play (preferir flujo centralizado del common.sh) ---
 if [ ! -f "$PLAY_PATH/play" ]; then
-  download_play_official "$PLAY_VERSION" "$PLAY_PATH"
+  install_play "$PLAY_VERSION"
 else
-  INSTALLED_PLAY_VERSION=$(cat "$PLAY_PATH/framework/src/play/version")
-  if [ "$INSTALLED_PLAY_VERSION" != "$PLAY_VERSION" ]; then
+  INSTALLED_PLAY_VERSION="$(cat "$PLAY_PATH/framework/src/play/version" 2>/dev/null || echo "")"
+  if [ "$INSTALLED_PLAY_VERSION" != "$PLAY_VERSION" ] && $VERSION_DECLARED; then
     echo "-----> Updating Play! from $INSTALLED_PLAY_VERSION to $PLAY_VERSION..."
     rm -rf "$PLAY_PATH"
-    download_play_official "$PLAY_VERSION" "$PLAY_PATH"
+    install_play "$PLAY_VERSION"
   fi
 fi
 
-echo "-----> Build complete."
+# --- Construcción de la app ---
+echo "-----> Building Play! application..."
+"$PLAY_PATH/play" version | indent
+
+APP_DIR="."
+echo "       Building app at $APP_DIR"
+
+DEPENDENCIES_CMD="$PLAY_PATH/play dependencies $APP_DIR --forProd --forceCopy --silent -Duser.home=$BUILD_DIR 2>&1"
+echo "       Resolving dependencies..."
+eval "$DEPENDENCIES_CMD" | indent
+check_compile_status
+
+PRECOMPILE_CMD="$PLAY_PATH/play precompile $APP_DIR --silent 2>&1"
+echo "       Precompiling application..."
+eval "$PRECOMPILE_CMD" | indent
+check_compile_status
+
+# --- Guardar cache ---
+for DIR in "$PLAY_PATH" "$IVY_PATH"; do
+  rm -rf "$CACHE_DIR/$DIR"
+  cp -r "$DIR" "$CACHE_DIR/$DIR"
+done
+
+# --- PATH de runtime ---
+PROFILE_PATH="$BUILD_DIR/.profile.d/play.sh"
+mkdir -p "$(dirname "$PROFILE_PATH")"
+cat > "$PROFILE_PATH" <<EOF
+export PATH="/app/.play:/app/.jdk/bin:/app/.tools:\$PATH"
+EOF
+
+# --- Limpiar deps de build ---
+rm -rf "$IVY_PATH"
+remove_play "$BUILD_DIR" "$PLAY_VERSION"
+
+# --- Procfile por defecto si no existe ---
+if [ ! -f Procfile ]; then
+  echo "-----> No Procfile found. Default process: "
+  echo "       play run --http.port=\$PORT \$PLAY_OPTS"
+fi

--- a/bin/release
+++ b/bin/release
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-BUILD_DIR=$1
+# bin/release <build-dir>
+BUILD_DIR="$1"
 
-cat <<EOF
+# (Opcional) variables por defecto visibles en la app
+cat <<'YAML'
 ---
 config_vars:
   #PLAY_OPTS: -Dprecompiled=true
-EOF
+YAML
 
+# Solo si la app NO trae Procfile, define el proceso web por defecto
 if [ ! -f "$BUILD_DIR/Procfile" ]; then
-cat <<'EOF'
+cat <<'YAML'
 default_process_types:
   web: ./.play/play run --http.port=$PORT $PLAY_OPTS
-EOF
+YAML
 fi

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,3 @@
-# bin/release
 #!/usr/bin/env bash
 BUILD_DIR=$1
 

--- a/bin/release
+++ b/bin/release
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-echo ">>> [DEBUG] bin/release ejecutado" >&2
+BUILD_DIR="$1"
 
-BUILD_DIR=$1
+# Mensajes de debug SOLO a stderr (no contaminan el YAML)
+echo ">>> [DEBUG] bin/release ejecutado (BUILD_DIR=$BUILD_DIR)" >&2
 
-cat <<EOF
+# Si la app NO trae Procfile, definimos el proceso web por defecto
+if [ ! -f "$BUILD_DIR/Procfile" ]; then
+  cat <<'YAML'
 ---
-config_vars:
-  #JAVA_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops
-  #PLAY_OPTS: --%prod -Dprecompiled=true
-  
-addons:
-  #heroku-postgresql
-  
-EOF
-
-if [ ! -f $BUILD_DIR/Procfile ]; then
-cat <<EOF
 default_process_types:
-  web:    play run --http.port=\$PORT \$PLAY_OPTS
-EOF
+  web: ./.play/play run --http.port=$PORT $PLAY_OPTS
+YAML
+else
+  # Si hay Procfile, igual debemos emitir YAML válido (vacío)
+  cat <<'YAML'
+---
+default_process_types: {}
+YAML
 fi

--- a/bin/release
+++ b/bin/release
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
-BUILD_DIR="$1"
 
-# (Opcional) variables por defecto visibles en la app
-cat <<'YAML'
+echo ">>> [DEBUG] bin/release ejecutado" >&2
+
+BUILD_DIR=$1
+
+cat <<EOF
 ---
 config_vars:
-  #PLAY_OPTS: -Dprecompiled=true
-YAML
+  #JAVA_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops
+  #PLAY_OPTS: --%prod -Dprecompiled=true
+  
+addons:
+  #heroku-postgresql
+  
+EOF
 
-# Solo si la app NO trae Procfile, define el proceso web por defecto
-if [ ! -f "$BUILD_DIR/Procfile" ]; then
-cat <<'YAML'
+if [ ! -f $BUILD_DIR/Procfile ]; then
+cat <<EOF
 default_process_types:
-  web: ./.play/play run --http.port=$PORT $PLAY_OPTS
-YAML
+  web:    play run --http.port=\$PORT \$PLAY_OPTS
+EOF
 fi

--- a/bin/release
+++ b/bin/release
@@ -1,22 +1,17 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
+set -euo pipefail
 
 BUILD_DIR="$1"
 
-# Mensajes de debug SOLO a stderr (no contaminan el YAML)
-echo ">>> [DEBUG] bin/release ejecutado (BUILD_DIR=$BUILD_DIR)" >&2
-
-# Si la app NO trae Procfile, definimos el proceso web por defecto
+# Si NO hay Procfile en la app, publicamos el proceso web por defecto
 if [ ! -f "$BUILD_DIR/Procfile" ]; then
-  cat <<'YAML'
----
-default_process_types:
-  web: ./.play/play run --http.port=$PORT $PLAY_OPTS
-YAML
+  # Escribe YAML puro a stdout (sin heredocs, sin expansión, sin eco previo)
+  printf '%s\n' '---' \
+                'default_process_types:' \
+                '  web: ./.play/play run --http.port=$PORT $PLAY_OPTS'
 else
-  # Si hay Procfile, igual debemos emitir YAML válido (vacío)
-  cat <<'YAML'
----
-default_process_types: {}
-YAML
+  # Si hay Procfile, igual devolvemos YAML válido
+  printf '%s\n' '---' \
+                'default_process_types: {}'
 fi

--- a/bin/release
+++ b/bin/release
@@ -1,22 +1,16 @@
+# bin/release
 #!/usr/bin/env bash
-# bin/release <build-dir>
-
 BUILD_DIR=$1
 
 cat <<EOF
 ---
 config_vars:
-  #JAVA_OPTS: -Xmx384m -Xss512k -XX:+UseCompressedOops
-  #PLAY_OPTS: --%prod -Dprecompiled=true
-  
-addons:
-  #heroku-postgresql
-  
+  #PLAY_OPTS: -Dprecompiled=true
 EOF
 
-if [ ! -f $BUILD_DIR/Procfile ]; then
-cat <<EOF
+if [ ! -f "$BUILD_DIR/Procfile" ]; then
+cat <<'EOF'
 default_process_types:
-  web:    play run --http.port=\$PORT \$PLAY_OPTS
+  web: ./.play/play run --http.port=$PORT $PLAY_OPTS
 EOF
 fi


### PR DESCRIPTION
## Summary by Sourcery

Sync buildpack to version 24 by refactoring common.sh utilities, improving error handling and debug output, enhancing Play! framework installation workflow, and adding support for OpenJDK 11

New Features:
- Support installation of OpenJDK 11 alongside existing Java 8

Bug Fixes:
- Improve detection of piped command failures in check_compile_status
- Fix parsing of Play! framework version from dependencies.yml

Enhancements:
- Enforce use of system curl and emit its path and version for debugging
- Refactor common.sh to split play installation into validate, download, and install steps
- Add fallback to official Play! zip download when release tarball isn’t available
- Allow overriding JDK download URL via JDK_URL and unify curl usage across functions
- Add set -e to common.sh to fail fast on errors and enhance error handling